### PR TITLE
Require dovecot::mailpackages before changing config files

### DIFF
--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -62,6 +62,7 @@ class dovecot::mail (
       mode    => '0644',
       owner   => root,
       group   => root,
+      require => Package[$::dovecot::mailpackages],
       before  => Exec['dovecot'],
     }
   }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -24,6 +24,7 @@ class dovecot::master (
         "set service[ . = \"auth\"]/unix_listener[ . = \"${postfix_path}\"]/user \"${postfix_username}\"",
         "set service[ . = \"auth\"]/unix_listener[ . = \"${postfix_path}\"]/group \"${postfix_groupname}\"",
         ],
+      require     => Package[$::dovecot::mailpackages]
     }
 
     dovecot::config::dovecotcfmulti { '/etc/dovecot/conf.d/10-master.conf-postfixlistener1':


### PR DESCRIPTION
@kronos-pbrideau Je sais pas si ça fait du sens, mais ça a l'air de pas sauter. Les deux fichiers de config étaient créés/modifiés avant la création du dossier.
